### PR TITLE
Add UniConsent benchmark with visible banner selector

### DIFF
--- a/benchmarks/with-uniconsent/app/layout.tsx
+++ b/benchmarks/with-uniconsent/app/layout.tsx
@@ -1,0 +1,25 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+
+export const metadata: Metadata = {
+	title: "benchmark",
+};
+
+export default function RootLayout({
+	children,
+}: Readonly<{
+	children: ReactNode;
+}>) {
+	return (
+		<html lang="en" suppressHydrationWarning>
+			<head>
+				{/* biome-ignore lint/nursery/noSyncScripts: UniConsent's install snippet requires synchronous stubs before the CMP script. */}
+				<script src="https://cmp.uniconsent.com/v2/stub.min.js" />
+				{/* biome-ignore lint/nursery/noSyncScripts: UniConsent's install snippet requires synchronous stubs before the CMP script. */}
+				<script src="https://cmp.uniconsent.com/v2/stubgcm.min.js" />
+				<script async src="https://cmp.uniconsent.com/v2/d73d9ba530/cmp.js" />
+			</head>
+			<body>{children}</body>
+		</html>
+	);
+}

--- a/benchmarks/with-uniconsent/app/page.tsx
+++ b/benchmarks/with-uniconsent/app/page.tsx
@@ -1,0 +1,7 @@
+export default function Home() {
+	return (
+		<div>
+			<h1>Benchmark</h1>
+		</div>
+	);
+}

--- a/benchmarks/with-uniconsent/config.json
+++ b/benchmarks/with-uniconsent/config.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "./node_modules/@cookiebench/benchmark-schema/schema.json",
+  "name": "with-uniconsent",
+  "id": "uniconsent-banner",
+  "iterations": 20,
+  "cookieBanner": {
+    "selectors": ["#uniccmp .unic-bar"],
+    "serviceHosts": [
+      "cmp.uniconsent.com",
+      "cdn.uniconsent.com",
+      "api.uniconsent.com"
+    ],
+    "waitForVisibility": true,
+    "measureViewportCoverage": true,
+    "expectedLayoutShift": true,
+    "serviceName": "UniConsent"
+  },
+  "internationalization": {
+    "detection": "ip",
+    "stringLoading": "server"
+  },
+  "techStack": {
+    "bundler": "unknown",
+    "bundleType": "iffe",
+    "frameworks": [],
+    "languages": ["javascript"],
+    "packageManager": "unknown",
+    "typescript": false
+  },
+  "source": {
+    "isOpenSource": false,
+    "license": "proprietary",
+    "website": "https://www.uniconsent.com"
+  },
+  "company": {
+    "name": "UniConsent",
+    "website": "https://www.uniconsent.com"
+  },
+  "includes": {
+    "backend": "proprietary",
+    "components": ["javascript"]
+  }
+}

--- a/benchmarks/with-uniconsent/next-env.d.ts
+++ b/benchmarks/with-uniconsent/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/benchmarks/with-uniconsent/next.config.ts
+++ b/benchmarks/with-uniconsent/next.config.ts
@@ -1,0 +1,7 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {
+	/* config options here */
+};
+
+export default nextConfig;

--- a/benchmarks/with-uniconsent/package.json
+++ b/benchmarks/with-uniconsent/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "with-uniconsent",
+  "private": true,
+  "scripts": {
+    "benchmark": "pnpm exec benchmark-cli benchmark",
+    "build": "next build",
+    "dev": "next dev --port 3000",
+    "fmt": "biome format . --write",
+    "lint": "biome lint .",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "16.0.7",
+    "react": "^19.2.1",
+    "react-dom": "^19.2.1"
+  },
+  "devDependencies": {
+    "@cookiebench/benchmark-schema": "workspace:*",
+    "@cookiebench/cli": "workspace:*",
+    "@cookiebench/ts-config": "workspace:*",
+    "@types/node": "^24.10.1",
+    "@types/react": "^19.2.7",
+    "@types/react-dom": "^19.2.3",
+    "typescript": "^5.9.3"
+  }
+}

--- a/benchmarks/with-uniconsent/tsconfig.json
+++ b/benchmarks/with-uniconsent/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "@cookiebench/ts-config/nextjs.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", ".next/types/**/*.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -422,6 +422,40 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
 
+  benchmarks/with-uniconsent:
+    dependencies:
+      next:
+        specifier: 16.0.7
+        version: 16.0.7(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      react:
+        specifier: ^19.2.1
+        version: 19.2.1
+      react-dom:
+        specifier: ^19.2.1
+        version: 19.2.1(react@19.2.1)
+    devDependencies:
+      '@cookiebench/benchmark-schema':
+        specifier: workspace:*
+        version: link:../../packages/benchmark-schema
+      '@cookiebench/cli':
+        specifier: workspace:*
+        version: link:../../packages/cli
+      '@cookiebench/ts-config':
+        specifier: workspace:*
+        version: link:../../packages/typescript-config
+      '@types/node':
+        specifier: ^24.10.1
+        version: 24.10.1
+      '@types/react':
+        specifier: ^19.2.7
+        version: 19.2.7
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.7)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
   benchmarks/with-usercentrics:
     dependencies:
       next:


### PR DESCRIPTION
## Summary
Adds a `with-uniconsent` benchmark app for UniConsent, configuring CookieBench metadata, visible banner selector, service hosts, and proprietary source/company fields.

## Project ID note
Existing external-script benchmarks commit public client-side vendor IDs/config URLs directly in source. This draft follows that shape, but currently uses a placeholder UniConsent project ID. For an upstream-ready benchmark, UniConsent should provide or approve a public benchmark/demo project ID configured for the benchmark host, as I don't have permission to publish the one I have access to.

The private project ID, host, config URL, and test URL used during local validation are not included in this PR. The current placeholder ID loads UniConsent scripts/config but does not render a visible banner locally.

## Local UniConsent result
Local UniConsent validation, 20 iterations:

| Application | Score | Banner Visibility | Network Impact | Bundle Strategy | Viewport Coverage | FCP | LCP | CLS |
| --- | ---: | ---: | ---: | --- | ---: | ---: | ---: | ---: |
| UniConsent | 61 | 378ms | 394bytes | IIFE Script | 36.3% | 70ms | 389ms | 0.001 |

Category scores from that run:

| Category | Score |
| --- | ---: |
| Performance | 83 |
| Bundle Strategy | 30 |
| Network Impact | 75 |
| Transparency | 30 |
| User Experience | 55 |

## Notes
- The benchmark mirrors UniConsent's vendor install pattern using native head scripts: synchronous stub scripts first, followed by the async CMP script.
- The synchronous stub script lint suppressions are scoped to those two tags because the UniConsent install snippet requires them before the CMP script.
- The selector targets `#uniccmp .unic-bar`, the visible bar rendered inside UniConsent's runtime container; `#uniccmp` itself is a zero-height wrapper.

## Validation
- `pnpm --filter with-uniconsent fmt`
- `pnpm --filter with-uniconsent lint`
- `pnpm --filter with-uniconsent exec tsc --noEmit --project tsconfig.json`
- `pnpm --filter with-uniconsent build`
